### PR TITLE
Implement Kong caching of limit quotas

### DIFF
--- a/kong/plugins/consumer-rate-limiting/daos.lua
+++ b/kong/plugins/consumer-rate-limiting/daos.lua
@@ -1,6 +1,7 @@
 local QUOTA_SCHEMA = {
   primary_key = {"consumer_id", "api_id"},
   table = "consumerratelimiting_quotas",
+  cache_key = {"consumer_id", "api_id"},
   fields = {
     consumer_id = {type = "string", required = true},
     api_id = {type = "string", required = true},

--- a/kong/plugins/consumer-rate-limiting/gateway.lua
+++ b/kong/plugins/consumer-rate-limiting/gateway.lua
@@ -2,8 +2,8 @@
 local function QuotaGateway(singletons)
   if singletons == nil then
     singletons = require "kong.singletons"
-    cache = singletons.cache
   end
+  cache = singletons.cache
 
   local self = {}
 
@@ -30,7 +30,6 @@ local function QuotaGateway(singletons)
     end
 
     local cache_key = singletons.dao.consumerratelimiting_quotas:cache_key(consumer_id, api_name)
-
     local quota, err = cache:get(cache_key, nil, find_quota_for_api, consumer_id)
 
     if quota == nil then


### PR DESCRIPTION
Resolves #1 

Uses the Kong caching mechanisms to cache database queries of limit quotas. It will honour the configuration of caching (e.g. expiry) and also should be invalidated correctly on a data update.
